### PR TITLE
docs: fix broken release badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Python CI](https://github.com/bjg-gh/style_transfer_visualizer/actions/workflows/python-ci.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![codecov](https://codecov.io/gh/bjg-gh/style_transfer_visualizer/branch/ci-test/graph/badge.svg)](https://codecov.io/gh/bjg-gh/style_transfer_visualizer)
-[![GitHub release](https://img.shields.io/github/v/release/bjg-gh/style-transfer-visualizer?sort=semver)](https://github.com/bjg-gh/style-transfer-visualizer/releases)
+![GitHub Release](https://img.shields.io/github/v/release/bjg-gh/style_transfer_visualizer?sort=semver)
 
 **Author**: [@bjg-gh](https://github.com/bjg-gh)
 


### PR DESCRIPTION
Closes #2

Updates the release badge in `README.md` to correctly reflect the latest public release.